### PR TITLE
Upgrade to OpenJDK 11.0.12

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         dockerfile: 11/jdk/slim-aws 
         image-name: openjdk
-        tags: 11-aws 11-jdk-aws 11-jdk-slim-aws 11.0.11-jdk-slim-aws
+        tags: 11-aws 11-jdk-aws 11-jdk-slim-aws 11.0.12-jdk-slim-aws
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -34,7 +34,7 @@ jobs:
       with:
         dockerfile: 11/jdk/slim 
         image-name: openjdk
-        tags: latest 11 11-jdk 11-jdk-slim 11.0.11-jdk-slim
+        tags: latest 11 11-jdk 11-jdk-slim 11.0.12-jdk-slim
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -53,7 +53,7 @@ jobs:
       with:
         dockerfile: 11/jdk/zulu
         image-name: openjdk
-        tags: 11-zulu 11-jdk-zulu 11-jdk-zulu 11.0.11-jdk-zulu
+        tags: 11-zulu 11-jdk-zulu 11-jdk-zulu 11.0.12-jdk-zulu
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -72,7 +72,7 @@ jobs:
       with:
         dockerfile: 11/jdk/zulu-docker
         image-name: openjdk
-        tags: 11-zulu-docker 11-jdk-zulu-docker 11-jdk-zulu-docker 11.0.11-jdk-zulu-docker
+        tags: 11-zulu-docker 11-jdk-zulu-docker 11-jdk-zulu-docker 11.0.12-jdk-zulu-docker
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -91,7 +91,7 @@ jobs:
       with:
         dockerfile: 11/jre/slim-aws 
         image-name: openjdk
-        tags: 11-jre-aws 11-jre-slim-aws 11.0.11-jre-slim-aws
+        tags: 11-jre-aws 11-jre-slim-aws 11.0.12-jre-slim-aws
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -110,7 +110,7 @@ jobs:
       with:
         dockerfile: 11/jre/slim
         image-name: openjdk
-        tags: 11-jre 11-jre-slim 11.0.11-jre-slim
+        tags: 11-jre 11-jre-slim 11.0.12-jre-slim
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/11/jdk/slim-aws/Dockerfile
+++ b/11/jdk/slim-aws/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV AWSCLI_VERSION 1.17.7
+ENV AWSCLI_VERSION 2.2.35
 
 RUN apt-get update && \
     apt-get install -y \
@@ -12,13 +12,16 @@ RUN apt-get update && \
       wget \
       curl \
       jq \
-      python \
-      python-pip \
       netcat-openbsd \
-      bash && \
-    pip install --no-cache-dir awscli==$AWSCLI_VERSION && \
+      bash \
+      unzip && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean 
+    apt-get clean && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$AWSCLI_VERSION.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    rm awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws
 
 ADD REPO .
 ADD TAGS .

--- a/11/jdk/slim-aws/Dockerfile
+++ b/11/jdk/slim-aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jdk-slim
+FROM openjdk:11.0.12-jdk-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 # Default to UTF-8 file.encoding

--- a/11/jdk/slim/Dockerfile
+++ b/11/jdk/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jdk-slim
+FROM openjdk:11.0.12-jdk-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 ARG MAVEN_VERSION="3.6.3"

--- a/11/jdk/zulu-docker/Dockerfile
+++ b/11/jdk/zulu-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:19.03.5 
+FROM docker:20.10.8 
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apk --no-cache add \
@@ -18,7 +18,7 @@ ENV LC_ALL en_US.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/zulu11-ca
 RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "https://repos.azul.com/zulu/alpine" >> /etc/apk/repositories && \
-    apk --no-cache add zulu11-jdk=11.0.11-r1
+    apk --no-cache add zulu11-jdk=11.0.12-r1
 
 RUN addgroup -S java && \
   adduser -S -G java java

--- a/11/jdk/zulu/Dockerfile
+++ b/11/jdk/zulu/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:11.0.11
+FROM azul/zulu-openjdk-alpine:11.0.12
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apk --no-cache add \

--- a/11/jre/slim-aws/Dockerfile
+++ b/11/jre/slim-aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jre-slim
+FROM openjdk:11.0.12-jre-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/11/jre/slim-aws/Dockerfile
+++ b/11/jre/slim-aws/Dockerfile
@@ -7,14 +7,18 @@ RUN apt-get update && \
       jq \
       openssl \
       net-tools \
-      python-pip \
       netcat-openbsd \
-      wget && \
+      wget \
+      unzip && \
     rm -rf /var/lib/apt/lists/*
 
-ENV AWSCLI_VERSION 1.16.237
+ENV AWSCLI_VERSION 2.2.35
 
-RUN pip install awscli==$AWSCLI_VERSION
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$AWSCLI_VERSION.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    rm awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws
 
 RUN addgroup --system java && \
     adduser --system --group java

--- a/11/jre/slim/Dockerfile
+++ b/11/jre/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jre-slim
+FROM openjdk:11.0.12-jre-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/openjdk:11 cat TAGS
-openjdk openjdk:11 openjdk:11-jdk openjdk:11-jdk-slim openjdk:11.0.11-jdk-slim
+openjdk openjdk:11 openjdk:11-jdk openjdk:11-jdk-slim openjdk:11.0.12-jdk-slim
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `openjdk:11` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -72,18 +72,18 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### openjdk
-- `openjdk`, `openjdk:11`, `openjdk:11-jdk`, `openjdk:11-jdk-slim`, `openjdk:11.0.11-jdk-slim` [11/jdk/slim/Dockerfile](11/jdk/slim/Dockerfile)
-- `openjdk:11-zulu`, `openjdk:11-jdk-zulu`, `openjdk:11-jdk-zulu`, `openjdk:11.0.11-jdk-zulu` [11/jdk/zulu/Dockerfile](11/jdk/zulu/Dockerfile)
-- `openjdk:11-jre`, `openjdk:11-jre-slim`, `openjdk:11.0.11-jre-slim` [11/jre/slim/Dockerfile](11/jre/slim/Dockerfile)
+- `openjdk`, `openjdk:11`, `openjdk:11-jdk`, `openjdk:11-jdk-slim`, `openjdk:11.0.12-jdk-slim` [11/jdk/slim/Dockerfile](11/jdk/slim/Dockerfile)
+- `openjdk:11-zulu`, `openjdk:11-jdk-zulu`, `openjdk:11-jdk-zulu`, `openjdk:11.0.12-jdk-zulu` [11/jdk/zulu/Dockerfile](11/jdk/zulu/Dockerfile)
+- `openjdk:11-jre`, `openjdk:11-jre-slim`, `openjdk:11.0.12-jre-slim` [11/jre/slim/Dockerfile](11/jre/slim/Dockerfile)
 - `openjdk:8`, `openjdk:8-jdk`, `openjdk:8-jdk-alpine`, `openjdk:8u292-jdk-alpine` [8/jdk/alpine/Dockerfile](8/jdk/alpine/Dockerfile)
 - `openjdk:8-jre`, `openjdk:8-jre-alpine`, `openjdk:8u292-jre-alpine` [8/jre/alpine/Dockerfile](8/jre/alpine/Dockerfile)
 
 ### openjdk with aws-cli
-- `openjdk:11-aws`, `openjdk:11-jdk-aws`, `openjdk:11-jdk-slim-aws`, `openjdk:11.0.11-jdk-slim-aws` [11/jdk/slim-aws/Dockerfile](11/jdk/slim-aws/Dockerfile)
-- `openjdk:11-jre-aws`, `openjdk:11-jre-slim-aws`, `openjdk:11.0.11-jre-slim-aws` [11/jre/slim-aws/Dockerfile](11/jre/slim-aws/Dockerfile)
+- `openjdk:11-aws`, `openjdk:11-jdk-aws`, `openjdk:11-jdk-slim-aws`, `openjdk:11.0.12-jdk-slim-aws` [11/jdk/slim-aws/Dockerfile](11/jdk/slim-aws/Dockerfile)
+- `openjdk:11-jre-aws`, `openjdk:11-jre-slim-aws`, `openjdk:11.0.12-jre-slim-aws` [11/jre/slim-aws/Dockerfile](11/jre/slim-aws/Dockerfile)
 
 ### openjdk with docker
-- `openjdk:11-zulu-docker`, `openjdk:11-jdk-zulu-docker`, `openjdk:11-jdk-zulu-docker`, `openjdk:11.0.11-jdk-zulu-docker` [11/jdk/zulu-docker/Dockerfile](11/jdk/zulu-docker/Dockerfile)
+- `openjdk:11-zulu-docker`, `openjdk:11-jdk-zulu-docker`, `openjdk:11-jdk-zulu-docker`, `openjdk:11.0.12-jdk-zulu-docker` [11/jdk/zulu-docker/Dockerfile](11/jdk/zulu-docker/Dockerfile)
 
 ## Why
 


### PR DESCRIPTION
The upgrade from openjdk:11.0.11-jdk-slim to openjdk:11.0.12-jdk-slim includes an upgrade from Debian 10 to Debian 11. This broke `apt-get install -y python-pip`. Therefore this pull request also upgrades the AWS CLI version to 2.2.35 which no longer needs Python.