### PR TITLE
Add pinned versions of github actions

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,14 +1,11 @@
 on: [push]
-
 name: build
-
 env:
   REGISTRY_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   REGISTRY_TOKEN: '${{ secrets.DOCKER_PASSWORD }}'
   DOCKER_ORGANIZATION: philipssoftware
   GITHUB_ORGANIZATION: philips-software
   KEYLESS: true
-
 jobs:
   build_container:
     runs-on: ubuntu-latest
@@ -42,9 +39,9 @@ jobs:
             dockerfile: 8/jre/alpine
             tags: 8-jre 8-jre-alpine 8u322-jre-alpine
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # ratchet:actions/checkout@v3
       - name: ${{ matrix.name }}
-        uses: philips-software/docker-ci-scripts@v5.1.0
+        uses: philips-software/docker-ci-scripts@d0045b844f08b0dcb4c62bd4acf6c36877404dae # ratchet:philips-software/docker-ci-scripts@v5.1.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
           image-name: openjdk


### PR DESCRIPTION
I've used [Ratchet](https://github.com/sethvargo/ratchet) to pin the versions.

Commandline:
```
find . -name "*.yml" -path "./.github/workflows/*" -exec ratchet pin {} \;
```